### PR TITLE
Add svn CLI helpers and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # svn-mcp
+
+A minimal Python helper package for interacting with Subversion (SVN). It
+provides a thin wrapper around the `svn` command line so scripts and tools can
+perform common operations programmatically.
+
+## Installation
+
+Clone the repository and install it in editable mode:
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+The package exposes a simple command line interface. For example, to checkout a
+repository and commit changes:
+
+```bash
+python -m svn_mcp checkout http://example.com/repo path/to/dest
+# make changes
+python -m svn_mcp commit "My commit message"
+```
+
+## Development
+
+Unit tests are located in the `tests/` directory and can be run with:
+
+```bash
+python -m unittest
+```

--- a/src/svn_mcp/__init__.py
+++ b/src/svn_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""svn_mcp package"""
+
+from . import svn_client

--- a/src/svn_mcp/__main__.py
+++ b/src/svn_mcp/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/svn_mcp/cli.py
+++ b/src/svn_mcp/cli.py
@@ -1,0 +1,23 @@
+import argparse
+from . import svn_client
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Simple SVN client wrapper")
+    subparsers = parser.add_subparsers(dest="command")
+
+    checkout_parser = subparsers.add_parser("checkout", help="Checkout repository")
+    checkout_parser.add_argument("url")
+    checkout_parser.add_argument("dest")
+
+    commit_parser = subparsers.add_parser("commit", help="Commit changes")
+    commit_parser.add_argument("message")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "checkout":
+        svn_client.checkout(args.url, args.dest)
+    elif args.command == "commit":
+        svn_client.commit(args.message)
+    else:
+        parser.print_help()

--- a/src/svn_mcp/svn_client.py
+++ b/src/svn_mcp/svn_client.py
@@ -1,0 +1,17 @@
+import subprocess
+from typing import List
+
+
+def _run_command(cmd: List[str]) -> subprocess.CompletedProcess:
+    """Internal helper to run a command using subprocess."""
+    return subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def checkout(url: str, dest: str) -> subprocess.CompletedProcess:
+    """Checkout an SVN repository to a destination directory."""
+    return _run_command(["svn", "checkout", url, dest])
+
+
+def commit(message: str) -> subprocess.CompletedProcess:
+    """Commit local changes with a commit message."""
+    return _run_command(["svn", "commit", "-m", message])

--- a/tests/test_svn_client.py
+++ b/tests/test_svn_client.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from svn_mcp import svn_client
+
+class TestSVNClient(unittest.TestCase):
+    @mock.patch('subprocess.run')
+    def test_checkout(self, mock_run):
+        svn_client.checkout('http://example.com/repo', 'dest')
+        mock_run.assert_called_with([
+            'svn', 'checkout', 'http://example.com/repo', 'dest'
+        ], check=True, capture_output=True, text=True)
+
+    @mock.patch('subprocess.run')
+    def test_commit(self, mock_run):
+        svn_client.commit('msg')
+        mock_run.assert_called_with([
+            'svn', 'commit', '-m', 'msg'
+        ], check=True, capture_output=True, text=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement svn client helper functions
- add CLI wrapper so package is runnable as a module
- provide unit tests with mocking
- update README with usage and instructions
- ignore Python cache files

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68403150c0f48327bd82e132ed8a5fc2