### PR TITLE
Add SVN update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ repository and commit changes:
 python -m svn_mcp checkout http://example.com/repo path/to/dest
 # make changes
 python -m svn_mcp commit "My commit message"
+# later update the working copy
+python -m svn_mcp update path/to/dest
 ```
 
 ## Development

--- a/src/svn_mcp/cli.py
+++ b/src/svn_mcp/cli.py
@@ -13,11 +13,16 @@ def main(argv=None):
     commit_parser = subparsers.add_parser("commit", help="Commit changes")
     commit_parser.add_argument("message")
 
+    update_parser = subparsers.add_parser("update", help="Update working copy")
+    update_parser.add_argument("path", nargs="?", default=".")
+
     args = parser.parse_args(argv)
 
     if args.command == "checkout":
         svn_client.checkout(args.url, args.dest)
     elif args.command == "commit":
         svn_client.commit(args.message)
+    elif args.command == "update":
+        svn_client.update(args.path)
     else:
         parser.print_help()

--- a/src/svn_mcp/svn_client.py
+++ b/src/svn_mcp/svn_client.py
@@ -15,3 +15,8 @@ def checkout(url: str, dest: str) -> subprocess.CompletedProcess:
 def commit(message: str) -> subprocess.CompletedProcess:
     """Commit local changes with a commit message."""
     return _run_command(["svn", "commit", "-m", message])
+
+
+def update(path: str = ".") -> subprocess.CompletedProcess:
+    """Update an existing SVN working copy."""
+    return _run_command(["svn", "update", path])

--- a/tests/test_svn_client.py
+++ b/tests/test_svn_client.py
@@ -22,6 +22,13 @@ class TestSVNClient(unittest.TestCase):
             'svn', 'commit', '-m', 'msg'
         ], check=True, capture_output=True, text=True)
 
+    @mock.patch('subprocess.run')
+    def test_update(self, mock_run):
+        svn_client.update('path')
+        mock_run.assert_called_with([
+            'svn', 'update', 'path'
+        ], check=True, capture_output=True, text=True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support updating a working copy via `svn update`
- expose `update` in CLI
- document the new command
- test update functionality

## Testing
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_6840353f92088327a164f0bf2caec1bc